### PR TITLE
Rework tests from the json file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,11 +98,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rustreexo"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
+ "serde",
  "serde_json",
  "sha2",
 ]
@@ -136,6 +155,20 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -160,10 +193,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ bitcoin_hashes = "0.7.6"
 sha2 = "0.10.2"
 
 [dev-dependencies]
-serde_json="1.0.81"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.81"

--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -251,7 +251,6 @@ impl Proof {
 
 #[cfg(test)]
 mod tests {
-    use core::panic;
     use std::{str::FromStr, vec};
 
     use bitcoin_hashes::{sha256, Hash, HashEngine};
@@ -350,29 +349,16 @@ mod tests {
     fn run_single_case(case: &serde_json::Value) {
         let mut s = Stump::new();
 
-        let mut hashes = Vec::new();
-
-        if let Some(roots) = case["roots"].as_array() {
-            for root in roots {
-                s.roots
-                    .push(bitcoin_hashes::sha256::Hash::from_str(root.as_str().unwrap()).unwrap());
-            }
-            s.leafs = case["leafs"].as_u64().expect("Missing leafs count");
-        } else if let Some(leafs) = case["leaf_values"].as_array() {
-            for i in leafs {
-                hashes.push(hash_from_u8(i.as_u64().unwrap() as u8));
-            }
-
-            s = s
-                .modify(&hashes, &vec![], &Proof::default())
-                .expect("Test stump is valid");
-        } else {
-            panic!("Missing test data");
+        let roots = case["roots"].as_array().expect("Missing roots");
+        for root in roots {
+            s.roots
+                .push(bitcoin_hashes::sha256::Hash::from_str(root.as_str().unwrap()).unwrap());
         }
+        s.leafs = case["numleaves"].as_u64().expect("Missing leafs count");
 
-        let json_targets = case["targets"].as_array().expect("Test case misformed");
-        let json_proof_hashes = case["proof"].as_array().expect("Test case misformed");
-        let json_del_values = case["values"].as_array();
+        let json_targets = case["targets"].as_array().expect("Missing targets");
+        let json_proof_hashes = case["proofhashes"].as_array().expect("Missing proofhashes");
+        let json_del_values = case["target_preimages"].as_array();
 
         let mut targets = vec![];
         let mut del_hashes = vec![];

--- a/src/accumulator/stump.rs
+++ b/src/accumulator/stump.rs
@@ -177,10 +177,10 @@ mod test {
     }
 
     fn run_case_with_deletion(case: &serde_json::Value) {
-        let leafs = get_json_field!("leaf_values", case);
+        let leafs = get_json_field!("leaf_preimages", case);
         let target_values = get_json_field!("target_values", case);
-        let roots = get_json_field!("roots", case);
-        let proof_hashes = get_json_field!("proof_hashes", case);
+        let roots = get_json_field!("expected_roots", case);
+        let proof_hashes = get_json_field!("proofhashes", case);
 
         let leafs = get_u64_array_from_obj!(leafs);
         let target_values = get_u64_array_from_obj!(target_values);
@@ -210,11 +210,11 @@ mod test {
 
     fn run_single_addition_case(case: &serde_json::Value) {
         let s = Stump::new();
-        let test_values = case["leaf_values"]
+        let test_values = case["leaf_preimages"]
             .as_array()
             .expect("Test data is missing");
 
-        let roots = case["roots"]
+        let roots = case["expected_roots"]
             .as_array()
             .expect("Fail reading roots for this case");
 

--- a/test_values/test_cases.json
+++ b/test_values/test_cases.json
@@ -1,22 +1,22 @@
 {
   "insertion_tests": [
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
-      "roots": [
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7],
+      "expected_roots": [
         "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
       ]
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6],
-      "roots": [
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6],
+      "expected_roots": [
         "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
         "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73",
         "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6"
       ]
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "roots": [
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+      "expected_roots": [
         "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42",
         "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8",
         "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0",
@@ -24,7 +24,7 @@
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         70, 13, 55, 152, 74, 33, 39, 122, 252, 53, 224, 211, 11, 25, 122, 14, 191, 152, 115,
         205, 160, 163, 90, 191, 199, 242, 216, 32, 141, 6, 200, 109, 211, 53, 72, 250, 108,
         163, 224, 90, 17, 25, 92, 254, 172, 211, 26, 231, 254, 159, 183, 180, 135, 131, 194,
@@ -37,7 +37,7 @@
         107, 79, 215, 226, 45, 0, 108, 43, 53, 218, 252, 71, 176, 54, 93, 0, 168, 238, 209, 41,
         198, 111, 235, 215, 216, 60, 135, 230, 205, 177, 102
       ],
-      "roots": [
+      "expected_roots": [
         "950c36521c4a3fa45862f31682f68b26af1e4a486fbf4d7f779a4bfcb8c9bbe9",
         "c9e5725dcf415c6eb0a2d381aa8b7678bc7a810ec46d8f330d4ef3ce023858bf",
         "a2402edac76acbf77c01dce0cdf0fbcf5e6e1acdf9eb97b891c2a6dc8582086a",
@@ -48,9 +48,46 @@
   ],
   "proof_tests": [
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
+      "numleaves": 6,
+      "roots": [
+        "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+      ],
+      "targets": [],
+      "target_preimages": [],
+      "proofhashes": [],
+      "expected": true
+    },
+    {
+      "numleaves": 6,
+      "roots": [
+        "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+      ],
+      "targets": [0, 1, 2, 3],
+      "target_preimages": [0, 1, 2, 3],
+      "proofhashes": [],
+      "expected": true
+    },
+    {
+      "numleaves": 6,
+      "roots": [
+        "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+      ],
+      "targets": [4, 5],
+      "target_preimages": [4, 5],
+      "proofhashes": [],
+      "expected": true
+    },
+    {
+      "numleaves": 8,
+      "roots": [
+        "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+      ],
       "targets": [0],
-      "proof": [
+      "target_preimages": [0],
+      "proofhashes": [
         "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
         "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
         "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
@@ -58,9 +95,85 @@
       "expected": true
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+      "numleaves": 8,
+      "roots": [
+        "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+      ],
+      "targets": [5, 3, 1],
+      "target_preimages": [5, 3, 1],
+      "proofhashes": [
+        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+        "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91"
+      ],
+      "expected": true
+    },
+    {
+      "numleaves": 8,
+      "roots": [
+        "859dad99dda0f8d0adb71f87a8b509fdfa9a0c1ab048399ca7b0da9fd6b258f8"
+      ],
+      "targets": [0, 9, 11],
+      "target_preimages": [0, 3, 7],
+      "proofhashes": [
+        "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+      ],
+      "expected": true
+    },
+    {
+      "numleaves": 8,
+      "roots": [
+        "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+      ],
+      "targets": [0],
+      "target_preimages": [0],
+      "proofhashes": [
+        "7cf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+        "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
+      ],
+      "expected": false,
+      "reason": "First proof hash is wrong"
+    },
+    {
+      "numleaves": 8,
+      "roots": [
+        "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+      ],
+      "targets": [0, 1, 2],
+      "target_preimages": [0, 1, 2],
+      "proofhashes": [
+        "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+        "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
+      ],
+      "expected": true
+    },
+    {
+      "numleaves": 8,
+      "roots": [
+        "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+      ],
+      "targets": [1, 2, 6],
+      "target_preimages": [1, 2, 6],
+      "proofhashes": [
+        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+        "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+      ],
+      "expected": true
+    },
+    {
+      "numleaves": 20,
+      "roots": [
+        "e121f8ffd6ca510cb55fe2d6373de3d018f7d2e9fbecb3a6d8342e1f9f6e6c7a",
+        "3cb920c113e8ce3ace35fc835e6ff83a6566c4c127ea67eebc0f5d25d2295ea2"
+      ],
       "targets": [0, 5],
-      "proof": [
+      "target_preimages": [0, 5],
+      "proofhashes": [
         "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
         "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
         "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
@@ -70,46 +183,15 @@
       "expected": true
     },
     {
-      "reason": "First proof hash is wrong",
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
-      "targets": [0],
-      "proof": [
-        "7cf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
-        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
-        "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
+      "numleaves": 100,
+      "roots": [
+        "72c32219411b8566bda58d4310b605f85a08b8eeb661b8c57e7ef09966fcc1eb",
+        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
+        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
       ],
-      "expected": false
-    },
-    {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
-      "targets": [0, 1, 2],
-      "proof": [
-        "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
-        "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
-      ],
-      "expected": true
-    },
-    {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
-      "targets": [1, 2, 6],
-      "proof": [
-        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
-        "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
-        "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
-        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
-      ],
-      "expected": true
-    },
-    {
-      "leaf_values": [
-                 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-                40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
-            ],
       "targets": [20, 30, 31, 32],
-      "proof": [
+      "target_preimages": [20, 30, 31, 32],
+      "proofhashes": [
         "2f0fd1e89b8de1d57292742ec380ea47066e307ad645f5bc3adad8a06ff58608",
         "bb7208bc9b5d7c04f1236a82a0093a5e33f40423d5ba8d4266f7092c3ba43b62",
         "60e6d84b9ad3355211af775aff3338289431744c79fc06f5e2c065cbdd690f79",
@@ -125,18 +207,15 @@
       "expected": true
     },
     {
-
-      "leaf_values": [
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-       20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-       40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-       60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-       80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
+      "numleaves": 100,
+      "roots": [
+        "72c32219411b8566bda58d4310b605f85a08b8eeb661b8c57e7ef09966fcc1eb",
+        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
+        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
       ],
-      "targets": [
-        99, 20, 19, 10, 30, 32, 31
-      ],
-      "proof": [
+      "targets": [99, 20, 19, 10, 30, 32, 31],
+      "target_preimages": [99, 20, 19, 10, 30, 32, 31],
+      "proofhashes": [
         "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
         "f299791cddd3d6664f6670842812ef6053eb6501bd6282a476bbbf3ee91e750c",
         "2f0fd1e89b8de1d57292742ec380ea47066e307ad645f5bc3adad8a06ff58608",
@@ -158,40 +237,15 @@
       "expected": true
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5],
-      "targets": [4, 5],
-      "proof": [],
-      "expected": true
-    },
-    {
-      "leaf_values": [0, 1, 2, 3, 4, 5],
-      "targets": [0, 1, 2, 3],
-      "proof": [],
-      "expected": true
-    },
-    {
-      "leafs": 8,
-      "targets": [0, 9, 11],
-      "proof": [
-        "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
-        "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
-      ],
+      "numleaves": 100,
       "roots": [
-        "859dad99dda0f8d0adb71f87a8b509fdfa9a0c1ab048399ca7b0da9fd6b258f8"
-      ],
-      "values": [0, 3, 7],
-      "expected": true
-    },
-    {
-      "leaf_values": [
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-       20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-       40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-       60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-       80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
+        "72c32219411b8566bda58d4310b605f85a08b8eeb661b8c57e7ef09966fcc1eb",
+        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
+        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
       ],
       "targets": [20, 19, 10, 30, 31, 32, 99],
-      "proof": [
+      "target_preimages": [20, 19, 10, 30, 31, 32, 99],
+      "proofhashes": [
         "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
         "f299791cddd3d6664f6670842812ef6053eb6501bd6282a476bbbf3ee91e750c",
         "2f0fd1e89b8de1d57292742ec380ea47066e307ad645f5bc3adad8a06ff58608",
@@ -209,82 +263,61 @@
         "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42",
         "94b8dc9cecafe156b80e4e64414cf4204858f56713776c525c38fb14c2c5e622",
         "8ec4ba1ba4d169b8a1e5261408d9799185d984206b1d8779e4a5c1e431023fc1"
-      ],
-      "expected": true
-    },
-    {
-      "leaf_values": [0, 1, 2, 3, 4, 5],
-      "targets": [],
-      "proof": [],
-      "expected": true
-    },
-    {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
-      "targets": [5, 3, 1],
-      "proof": [
-        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
-        "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
-        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
-        "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91"
       ],
       "expected": true
     }
   ],
   "deletion_tests": [
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7],
       "target_values": [1, 7],
-      "roots": [
-        "332c306188d35eb22ecb05d8c00446cd6a7a475f6615f46207cfaa713bb3e62c"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
         "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
         "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
         "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+      ],
+      "expected_roots": [
+        "332c306188d35eb22ecb05d8c00446cd6a7a475f6615f46207cfaa713bb3e62c"
       ]
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7],
       "target_values": [1, 5, 7],
-      "roots": [
-        "3b8b6eb231437092f6d9fbf8a0696b7cb446e40f1bf81ddb23d3eabb3080b0dd"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
        "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b"
+      ],
+      "expected_roots": [
+        "3b8b6eb231437092f6d9fbf8a0696b7cb446e40f1bf81ddb23d3eabb3080b0dd"
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
       ],
       "target_values": [1, 10],
-      "roots": [
-        "37968ef73d30dda38ede8357d66593c72acd4f0eb9f7a1a9acfeb7de850c05b4",
-        "3cb920c113e8ce3ace35fc835e6ff83a6566c4c127ea67eebc0f5d25d2295ea2"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
         "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
         "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
         "cd9c77062a338e63a63ca623db438cb8676f15466641079ee61ec2dda98de796",
         "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7",
         "e799acb98a071c4884707e4bc8c093ba22571c8d84cc0223ab0c2c9327313a5b"
+      ],
+      "expected_roots": [
+        "37968ef73d30dda38ede8357d66593c72acd4f0eb9f7a1a9acfeb7de850c05b4",
+        "3cb920c113e8ce3ace35fc835e6ff83a6566c4c127ea67eebc0f5d25d2295ea2"
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
       ],
       "target_values": [1, 10, 16],
-      "roots": [
-        "37968ef73d30dda38ede8357d66593c72acd4f0eb9f7a1a9acfeb7de850c05b4",
-        "21326d8aebeb6ef7bc02f40bdf778a02ba1c836b257f946ae21cab2a6f95fa18"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
         "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
         "4a64a107f0cb32536e5bce6c98c393db21cca7f4ea187ba8c4dca8b51d4ea80a",
@@ -293,84 +326,88 @@
         "96d56447466674521007145ed72f8757517c72f7737dc4a0dcd3ecb996968971",
         "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7",
         "e799acb98a071c4884707e4bc8c093ba22571c8d84cc0223ab0c2c9327313a5b"
+      ],
+      "expected_roots": [
+        "37968ef73d30dda38ede8357d66593c72acd4f0eb9f7a1a9acfeb7de850c05b4",
+        "21326d8aebeb6ef7bc02f40bdf778a02ba1c836b257f946ae21cab2a6f95fa18"
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       ],
       "target_values": [1, 10, 5],
-      "roots": [
+      "proofhashes": [
+        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+        "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
+        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+        "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91",
+        "cd9c77062a338e63a63ca623db438cb8676f15466641079ee61ec2dda98de796"
+      ],
+      "expected_roots": [
         "e4676ba63c94588bcb4083e5474063b633aa631897ddaabde7a4da45936890cb",
         "cae921bbf649d4dd84c252c55c540e2e30c6c00cb089d9704bd613ecea308643",
         "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0",
         "4d7b3ef7300acf70c892d8327db8272f54434adbc61a4e130a563cb59a0d0f47"
+      ]
+    },
+    {
+      "leaf_preimages": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       ],
-      "proof_hashes": [
-        "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+      "target_values": [0, 1, 10, 5],
+      "proofhashes": [
         "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
         "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
         "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
         "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91",
         "cd9c77062a338e63a63ca623db438cb8676f15466641079ee61ec2dda98de796"
-      ]
-    },
-    {
-      "leaf_values": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       ],
-      "target_values": [0, 1, 10, 5],
-      "roots": [
+      "expected_roots": [
         "352d0d5e172316e73b6d0d40605ad411c79b7e7c1ed0b4529c565f08057bc4a8",
         "cae921bbf649d4dd84c252c55c540e2e30c6c00cb089d9704bd613ecea308643",
         "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0",
         "4d7b3ef7300acf70c892d8327db8272f54434adbc61a4e130a563cb59a0d0f47"
-      ],
-      "proof_hashes": [
-        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
-        "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
-        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
-        "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91",
-        "cd9c77062a338e63a63ca623db438cb8676f15466641079ee61ec2dda98de796"
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       ],
       "target_values": [0, 1, 5, 14],
-      "roots":[
+      "proofhashes": [
+        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+        "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91"
+      ],
+      "expected_roots":[
         "352d0d5e172316e73b6d0d40605ad411c79b7e7c1ed0b4529c565f08057bc4a8",
         "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8",
         "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0",
         "0000000000000000000000000000000000000000000000000000000000000000"
-      ],
-      "proof_hashes": [
-        "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
-        "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
-        "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91"
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       ],
       "target_values": [1, 6, 5, 3],
-      "roots": [
-        "d6ab1f11dd0ceee1862aa84b5e4d2c7520a8651fa2652529e8c49cc2b43b4476",
-        "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8",
-        "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0",
-        "4d7b3ef7300acf70c892d8327db8272f54434adbc61a4e130a563cb59a0d0f47"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
         "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
         "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
         "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+      ],
+      "expected_roots": [
+        "d6ab1f11dd0ceee1862aa84b5e4d2c7520a8651fa2652529e8c49cc2b43b4476",
+        "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8",
+        "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0",
+        "4d7b3ef7300acf70c892d8327db8272f54434adbc61a4e130a563cb59a0d0f47"
       ]
     },
     {
-      "leaf_values": [
+      "leaf_preimages": [
         0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
        40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
@@ -378,12 +415,7 @@
        80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
       ],
       "target_values": [0, 1, 2, 4, 5, 9],
-      "roots": [
-        "2bd42a5f0ea1798ba955bab6f3ef2e920c8cf7dc9fd205e73c73bd54af706e2a",
-        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
-        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
         "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
         "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91",
@@ -391,10 +423,15 @@
         "e799acb98a071c4884707e4bc8c093ba22571c8d84cc0223ab0c2c9327313a5b",
         "a9597b23de170cbd52de7b993e5fa70b89536485d7c3e0309245bffdf13290ad",
         "e2a793580a9b6c9dff9d7f333f68ed708e9aa6232d2a1dc1e921be09949450c9"
+      ],
+      "expected_roots": [
+        "2bd42a5f0ea1798ba955bab6f3ef2e920c8cf7dc9fd205e73c73bd54af706e2a",
+        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
+        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
       ]
     },
     {
-      "leaf_values":  [
+      "leaf_preimages":  [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
         40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
@@ -402,59 +439,59 @@
         80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
       ],
       "target_values":  [38],
-      "roots": [
-        "2a722b6de15cfb2771f91613ab098bdb9b7f9731ac05992aba76d02aecff591e",
-        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
-        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "265fda17a34611b1533d8a281ff680dc5791b0ce0a11c25b35e11c8e75685509",
         "7c804d37a0128caccf89b63d53248b708d4e6702dbdd90b01cdf8bf2be45d0f8",
         "b743944ca9a4e59a94fd2f32adc6d40f800a012098d7d96aab47cd3883ee7810",
         "94b8dc9cecafe156b80e4e64414cf4204858f56713776c525c38fb14c2c5e622",
         "8ec4ba1ba4d169b8a1e5261408d9799185d984206b1d8779e4a5c1e431023fc1",
         "c20eb2e3805095a3a63d869af5fde12237ba512104438ad914b1c0e2a53743a2"
+      ],
+      "expected_roots": [
+        "2a722b6de15cfb2771f91613ab098bdb9b7f9731ac05992aba76d02aecff591e",
+        "0a2c57a002817e70a57e44d88ce570c3b197bd54047d5883b469c0ba0df6257e",
+        "33436f0f467c317f77eb7bf06dd182e90fd41ad27d34d09923866d89f41c4c27"
       ]
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
       "target_values":[0, 4, 5, 6, 7, 8],
-      "roots":[
-        "2b77298feac78ab51bc5079099a074c6d789bd350442f5079fcba2b3402694e5",
-        "84915b5adf9243dd83d67bb7d25b7a0c595ea1c37b97412e21e480c1a46f93bf"
-      ],
-      "proof_hashes": [
+      "proofhashes": [
         "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
         "2b4c342f5433ebe591a1da77e013d1b72475562d48578dca8b84bac6651c3cb9",
         "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
         "c413035120e8c9b0ca3e40c93d06fe60a0d056866138300bb1f1dd172b4923c3"
+      ],
+      "expected_roots":[
+        "2b77298feac78ab51bc5079099a074c6d789bd350442f5079fcba2b3402694e5",
+        "84915b5adf9243dd83d67bb7d25b7a0c595ea1c37b97412e21e480c1a46f93bf"
       ]
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
-      "target_values":[0, 1, 2, 3, 4, 5, 6, 7],
-      "roots":[
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7],
+      "target_values": [0, 1, 2, 3, 4, 5, 6, 7],
+      "expected_roots": [
         "0000000000000000000000000000000000000000000000000000000000000000"
       ],
-      "proof_hashes": []
+      "proofhashes": []
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7],
       "target_values": [0, 1, 2, 3],
-      "roots": [
+      "expected_roots": [
         "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
       ],
-      "proof_hashes": [
+      "proofhashes": [
         "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
       ]
     },
     {
-      "leaf_values": [0, 1, 2, 3, 4, 5, 6, 7],
+      "leaf_preimages": [0, 1, 2, 3, 4, 5, 6, 7],
       "target_values": [0, 2, 4, 6],
-      "roots": [
+      "expected_roots": [
         "54128834807e7f8763ff00fef2e7aea740c1d19977f95ee138ee6eecd0b9c702"
       ],
-      "proof_hashes": [
+      "proofhashes": [
         "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
         "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
         "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",


### PR DESCRIPTION
### (This PR may be broken in two, if requested)

The first commit makes the field naming similar to [pytreexo](https://www.github.com/utreexo/pytreexo). On the other hand, 0d20448 improves how our test code reads from `test_cases.json`. Instead of parsing json manually, I'm using a struct and serde_json to deserialize into a native struct, this makes the code cleaner and easier to read.
