### PR TITLE
Update deletion for caching

### DIFF
--- a/test_values/cache_tests.json
+++ b/test_values/cache_tests.json
@@ -17,7 +17,9 @@
             "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
             "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
         ],
-        "to_destroy": []
+        "to_destroy": [],
+        "new_del_pos": [],
+        "new_del_hashes": []
     },
     {
         "initial_stump": "Add six leaves [0, 1, 2, 3, 4, 5]",
@@ -44,7 +46,9 @@
             "df12e87db0413ef51d5bbd374904eeeb5cc4615ddae80e45a7140983f30cd01c",
             "b6b70236289cd59beebc247e8045f2c1293996ad881e756b79f01e275bc98fa1"
         ],
-        "to_destroy": []
+        "to_destroy": [],
+        "new_del_pos": [],
+        "new_del_hashes": []
     },
     {
         "initial_stump": "Add four leaves [0, 1, 2, 3] and remove them",
@@ -89,7 +93,9 @@
             "4fa0cac492b54bd78886ad14002aa71ca9c038cc1bea035bc27f67803031f0bc",
             "b50340a8c59e66c01d81923f4f834a07966866d2cdfdfba87204a7532f3368c5"
         ],
-        "to_destroy": [48]
+        "to_destroy": [48],
+        "new_del_pos": [],
+        "new_del_hashes": []
     }    ,
     {
         "initial_stump": "Add four leaves [0, 1, 2, 3] and remove them",
@@ -112,7 +118,9 @@
             "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
             "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
         ],
-        "to_destroy": [24]
+        "to_destroy": [24],
+        "new_del_pos": [],
+        "new_del_hashes": []
     },
     {
         "initial_stump":"Add six leaves [0, 1, 2, 3, 4, 5] and remove [0, 1, 2, 3]",
@@ -137,6 +145,188 @@
             "02242b37d8e851f1e86f46790298c7097df06893d6226b7c1453c213e91717de",
             "df12e87db0413ef51d5bbd374904eeeb5cc4615ddae80e45a7140983f30cd01c"
         ],
-        "to_destroy": [24]
+        "to_destroy": [24],
+        "new_del_pos": [],
+        "new_del_hashes": []
+    },
+    {
+        "initial_stump": "Add six leaves [0, 1, 2, 3, 4, 5]",
+        "roots": [
+            "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+            "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+        ],
+        "leaves": 6,
+        "additional_preimages": [0, 1, 2, 3, 4],
+        "del_hashes": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5"
+        ],
+        "proof_hashes": [],
+        "proof_targets": [0, 1, 2, 3],
+        "new_add_pos": [8, 9, 10, 18, 19, 20, 24, 25, 28],
+        "new_add_hash": [
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+            "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73",
+            "02242b37d8e851f1e86f46790298c7097df06893d6226b7c1453c213e91717de",
+            "df12e87db0413ef51d5bbd374904eeeb5cc4615ddae80e45a7140983f30cd01c"
+        ],
+        "to_destroy": [24],
+        "new_del_pos": [0, 1, 2, 3, 8, 9, 12],
+        "new_del_hashes": [
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        ]
+    },
+    {
+        "initial_stump": "Add sixteen leaves [0..15]",
+        "roots": [
+            "e121f8ffd6ca510cb55fe2d6373de3d018f7d2e9fbecb3a6d8342e1f9f6e6c7a"
+        ],
+        "leaves": 16,
+        "additional_preimages": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "del_hashes": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "ef6cbd2161eaea7943ce8693b9824d23d1793ffb1c0fca05b600d3899b44c977",
+            "4d7b3ef7300acf70c892d8327db8272f54434adbc61a4e130a563cb59a0d0f47"
+        ],
+        "proof_hashes": [
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "9d1e0e2d9459d06523ad13e28a4093c2316baafe7aec5b25f30eba2e113599c4",
+            "dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8",
+            "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73",
+            "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8"
+        ],
+        "proof_targets": [0, 2, 7, 12, 14],
+        "new_add_pos": [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 40, 41, 42, 43, 44, 52, 53, 58],
+        "new_add_hash": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
+            "2b4c342f5433ebe591a1da77e013d1b72475562d48578dca8b84bac6651c3cb9",
+            "02242b37d8e851f1e86f46790298c7097df06893d6226b7c1453c213e91717de",
+            "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+            "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73",
+            "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91",
+            "cd9c77062a338e63a63ca623db438cb8676f15466641079ee61ec2dda98de796",
+            "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+            "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7",
+            "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+        ],
+        "to_destroy": [],
+        "new_del_pos": [0, 2, 7, 12, 14, 16, 17, 19, 22, 23, 24, 25, 27, 28, 29, 30],
+        "new_del_hashes": [
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "9d1e0e2d9459d06523ad13e28a4093c2316baafe7aec5b25f30eba2e113599c4",
+            "dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8",
+            "2a5dfed9fadc41b06ccf51eecaac722501dc8a41ab97f97294067474dd26b8b3",
+            "916ec36f1627362c555266d07201f2ac9efeb922d888dc7bf99e36128f9ef478",
+            "07c89036529b25c3dde3136dcc94f6c4f382a7b8e51b16b90cba78c77b9f865b",
+            "6d4d4887ed4c733278b3c54d7c93ca49a6784ac64d291fd53b9f028e1b3bd437",
+            "dfb82c049fd0437275a2f4fed489ad0f5f7e393e64ec4341903ca9e5f111eb56",
+            "212ccae5bdd55479d27dd00a1ab4d3895b7f979fcb632e96f0838b4b9fb81fc2"
+        ]
+    },
+    {
+        "initial_stump": "Add seventeen leaves [0..16] and remove [0, 2, 7, 10, 12, 14, 15, 16]",
+        "roots": [
+            "e121f8ffd6ca510cb55fe2d6373de3d018f7d2e9fbecb3a6d8342e1f9f6e6c7a",
+            "c555eab45d08845ae9f10d452a99bfcb06f74a50b988fe7e48dd323789b88ee3"
+        ],
+        "leaves": 17,
+        "additional_preimages": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "del_hashes": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+            "ef6cbd2161eaea7943ce8693b9824d23d1793ffb1c0fca05b600d3899b44c977",
+            "4d7b3ef7300acf70c892d8327db8272f54434adbc61a4e130a563cb59a0d0f47",
+            "dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8",
+            "c555eab45d08845ae9f10d452a99bfcb06f74a50b988fe7e48dd323789b88ee3"
+        ],
+        "proof_hashes": [
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
+            "9d1e0e2d9459d06523ad13e28a4093c2316baafe7aec5b25f30eba2e113599c4",
+            "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73",
+            "cd9c77062a338e63a63ca623db438cb8676f15466641079ee61ec2dda98de796"
+        ],
+        "proof_targets": [0, 2, 7, 10, 12, 14, 15, 16],
+        "new_add_hash": [
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
+            "2b4c342f5433ebe591a1da77e013d1b72475562d48578dca8b84bac6651c3cb9",
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "decbf4fde875e0d232a5c5d7ccb84a4da20fbf99a543b9a11a02b63caf0880d0",
+            "1ece3ba6f716d45df9b99861d240d005bdc691f01944a14b3ba44db529eac23b",
+            "a0166933556ce419e69f7bd2b9718ecdbd0eece4655c70d15b9735b51a20f734",
+            "200a42d68adc8d8c921a069562401993d3ff317643997cb4d1ad238e5e384495",
+            "9651608a363b3b9c453ac558257994dc4a7a46b894948bc2d88c066a961768c0",
+            "b593cd7dae85fcb7afd368c9f50e0e7547ec3c6b764c00bd0e065ae891084d45",
+            "9c7ef9d21c2012d7840d818b32a3543ee598504f7e3365abdc7b734ef53e9b3b"
+        ],
+        "new_add_pos": [18, 19, 20, 21, 22, 23, 24, 25, 26, 40, 41, 42, 43, 44, 52, 53, 58],
+        "to_destroy": [16],
+        "new_del_pos": [0, 2, 7, 10, 12, 14, 15, 16, 32, 33, 35, 37, 38, 39, 48, 49, 50, 51, 56, 57, 60],
+        "new_del_hashes": [
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
+            "9d1e0e2d9459d06523ad13e28a4093c2316baafe7aec5b25f30eba2e113599c4",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "2a5dfed9fadc41b06ccf51eecaac722501dc8a41ab97f97294067474dd26b8b3",
+            "916ec36f1627362c555266d07201f2ac9efeb922d888dc7bf99e36128f9ef478",
+            "cae921bbf649d4dd84c252c55c540e2e30c6c00cb089d9704bd613ecea308643",
+            "9d1e0e2d9459d06523ad13e28a4093c2316baafe7aec5b25f30eba2e113599c4",
+            "6d4d4887ed4c733278b3c54d7c93ca49a6784ac64d291fd53b9f028e1b3bd437",
+            "5db9cfdf2da162c898f7654515559e4d080b27c2b394cae35004f228a581c7dd",
+            "af096f07a6e6ac0c0cac0a00094ac1a7166d8fd30051ca84bb6bf262fc1b042b"
+        ]
     }
 ]


### PR DESCRIPTION
~~This PR depends on #13 and #15; hence it's marked as draft.~~

This finalizes the implementation of required support data for proof update, now we also return which nodes have been updated during deletion.
Required for #12.