### PR TITLE
Implementation of Proof::Update

### DIFF
--- a/test_values/cached_proof_tests.json
+++ b/test_values/cached_proof_tests.json
@@ -1,0 +1,379 @@
+[
+    {
+        "update": {
+            "adds": [20, 21, 22],
+            "proof": {
+                "targets": [0, 1],
+                "hashes": [
+                    "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+                    "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
+                ]
+            },
+            "del_hashes": [
+                "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+                "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+            ]
+        },
+        "remembers": [],
+        "cached_proof": {
+            "targets": [4, 6, 7],
+            "hashes": [
+                "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+                "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
+            ]
+        },
+        "initial_stump": "Add 8 leaves [0, 1, 2, 3, 4, 5, 6, 7]",
+        "initial_roots": [
+            "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+        ],
+        "initial_leaves": 8,
+        "cached_hashes": [
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ],
+        "expected_roots": [
+            "97491b30a42410dc3267d17933cf5e1b55cfb92ebab2dcf1bcd098032dacee95",
+            "0d451c2d9366705a3557fd038c25a40a348cc0effa2dd00dfaaba65749cd0915",
+            "7cb7c4547cf2653590d7a9ace60cc623d25148adfbc88a89aeb0ef88da7839ba"
+        ],
+        "expected_targets": [4, 6, 7],
+        "expected_cached_hashes": [
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ]
+    },
+    {
+        "update": {
+            "adds": [8],
+            "proof": {
+                "targets": [0, 1, 4],
+                "hashes": [
+                    "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+                    "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+                    "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91"
+                ]
+            },
+            "del_hashes": [
+                "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+                "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+                "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71"
+            ]
+        },
+        "remembers": [0],
+        "cached_proof": {
+            "targets": [4, 6, 7],
+            "hashes": [
+                "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+                "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
+            ]
+        },
+        "initial_stump": "Add 8 leaves [0, 1, 2, 3, 4, 5, 6, 7]",
+        "initial_roots": [
+            "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+        ],
+        "initial_leaves": 8,
+        "cached_hashes": [
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ],
+        "expected_roots": [
+            "7f6df6757821144278f5d535261ab4ffc55e2618f7bc62f1a19e7d289061b08b",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a"
+        ],
+        "expected_targets": [6, 7, 8],
+        "expected_cached_hashes": [
+            "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a"
+        ]
+    },
+    {
+        "update": {
+            "adds": [8],
+            "proof": {
+                "targets": [4],
+                "hashes": [
+                    "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+                    "34028bbc87000c39476cdc60cf80ca32d579b3a0e2d3f80e0ad8c3739a01aa91",
+                    "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
+                ]
+            },
+            "del_hashes": [
+                "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71"
+            ]
+        },
+        "remembers": [0],
+        "cached_proof": {
+            "targets": [4, 5, 7],
+            "hashes": [
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+                "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
+            ]
+        },
+        "initial_stump": "Add 8 leaves [0, 1, 2, 3, 4, 5, 6, 7]",
+        "initial_roots": [
+            "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+        ],
+        "initial_leaves": 8,
+        "cached_hashes": [
+            "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ],
+        "expected_roots": [
+            "f1e8f77fb6c03d3e62acc1824e6671da21bb643f362a9af5171167bfdfbbb9cd",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a"
+        ],
+        "expected_targets": [7, 8, 18],
+        "expected_cached_hashes": [
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db"
+        ]
+    },
+    {
+        "update": {
+            "adds": [],
+            "proof": {
+                "targets": [4, 5, 6, 7],
+                "hashes": [
+                    "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386"
+                ]
+            },
+            "del_hashes": [
+                "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+                "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+                "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+            ]
+        },
+        "remembers": [],
+        "cached_proof": {
+            "targets": [1, 8, 12],
+            "hashes": [
+                "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+                "2b4c342f5433ebe591a1da77e013d1b72475562d48578dca8b84bac6651c3cb9",
+                "9d1e0e2d9459d06523ad13e28a4093c2316baafe7aec5b25f30eba2e113599c4",
+                "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+                "c413035120e8c9b0ca3e40c93d06fe60a0d056866138300bb1f1dd172b4923c3",
+                "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
+            ]
+        },
+        "initial_stump": "Add 14 leaves [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]",
+        "initial_roots": [
+            "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42",
+            "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8",
+            "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0"
+        ],
+        "initial_leaves": 14,
+        "cached_hashes": [
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
+            "ef6cbd2161eaea7943ce8693b9824d23d1793ffb1c0fca05b600d3899b44c977"
+        ],
+        "expected_roots": [
+            "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+            "9c053db406c1a077112189469a3aca0573d3481bef09fa3d2eda3304d7d44be8",
+            "55d0a0ef8f5c25a9da266b36c0c5f4b31008ece82df2512c8966bddcc27a66a0"
+        ],
+        "expected_targets": [8, 12, 17],
+        "expected_cached_hashes": [
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a",
+            "ef6cbd2161eaea7943ce8693b9824d23d1793ffb1c0fca05b600d3899b44c977",
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+        ]
+    },
+    {
+        "update": {
+            "adds": [],
+            "proof": {
+                "targets": [0],
+                "hashes": [
+                    "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+                    "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+                    "29590a14c1b09384b94a2c0e94bf821ca75b62eacebc47893397ca88e3bbcbd7"
+                ]
+            },
+            "del_hashes": [
+                "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+            ]
+        },
+        "remembers": [],
+        "cached_proof": {
+            "targets": [0, 7],
+            "hashes": [
+                "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a",
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+                "9576f4ade6e9bc3a6458b506ce3e4e890df29cb14cb5d3d887672aef55647a2b",
+                "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+            ]
+        },
+        "initial_stump": "Add 8 leaves [0, 1, 2, 3, 4, 5, 6, 7]",
+        "initial_roots": [
+            "b151a956139bb821d4effa34ea95c17560e0135d1e4661fc23cedc3af49dac42"
+        ],
+        "initial_leaves": 8,
+        "cached_hashes": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ],
+        "expected_roots": [
+            "726fdd3b432cc59e68487d126e70f0db74a236267f8daeae30b31839a4e7ebed"
+        ],
+        "expected_targets": [7],
+        "expected_cached_hashes": [
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ]
+    },
+
+    {
+        "update": {
+            "adds": [],
+            "proof": {
+                "targets": [3, 6],
+                "hashes": [
+                    "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+                    "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+                    "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+                    "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+                    "7a5db95c85dd117a20ca1b5b2ef50f61ee9529f40a957d97757c3a5b5ca7f5dd",
+                    "2c358bbc9182d5eaf8ae15c50fbe0dcd45fc794bdc73eafffddedbb0f6bab327"
+                ]
+            },
+            "del_hashes": [
+                "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6"
+            ]
+        },
+        "remembers": [],
+        "cached_proof": {
+            "targets": [2, 3, 7, 32, 34, 50, 52],
+            "hashes": [
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6",
+                "e799acb98a071c4884707e4bc8c093ba22571c8d84cc0223ab0c2c9327313a5b",
+                "ff4b5145903ab6a21824078a0f2bce2fb27739e9e80aa8195f2d3be70b12fc79",
+                "d1366f2a8c5a8fe1fc9b581a759ab6333e8d1683c74e09904d5acb50a9bffd5b"
+            ]
+        },
+        "initial_stump": "Add 32 leaves [0, 1, 2, 3, 4, ... 29, 30, 31], then delete [1, 4, 8, 9, 10, 16, 17, 18]",
+        "initial_roots": [
+            "0f434fd19b46d19ad44dd83b205c8e8c00f1b6d5701427f2c0524304dcbdf1d8"
+        ],
+        "initial_leaves": 32,
+        "cached_hashes": [
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
+            "ab897fbdedfa502b2d839b6a56100887dccdc507555c282e59589e06300a62e2"
+        ],
+        "expected_roots": [
+            "bbe46ee06d681bb5bad60c1b4860566e5e78b489b227cf927ecfbde599163dda"
+        ],
+        "expected_targets": [32, 33, 34, 35, 50, 52],
+        "expected_cached_hashes": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6",
+            "ab897fbdedfa502b2d839b6a56100887dccdc507555c282e59589e06300a62e2"
+        ]
+    },
+    {
+        "update": {
+            "adds": [],
+            "proof": {
+                "targets": [3, 6],
+                "hashes": [
+                    "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+                    "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+                    "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+                    "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db"
+                ]
+            },
+            "del_hashes": [
+                "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6"
+            ]
+        },
+        "remembers": [],
+        "cached_proof": {
+            "targets": [2, 3, 7, 16, 18, 26],
+            "hashes": [
+                "67586e98fad27da0b9968bc039a1ef34c939b9b8e523a8bef89d478608c5ecf6"
+            ]
+        },
+        "initial_stump": "Add 12 leaves [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], then delete [1, 4, 8, 9, 10]",
+        "initial_roots": [
+            "5093a5ae2bceeef66d9af3f4f1ed71acffe4932cd02afca5d2dc659dca5c418f",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6"
+        ],
+        "initial_leaves": 12,
+        "cached_hashes": [
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6"
+        ],
+        "expected_roots": [
+            "2bfc2e9199263e7b2ef762afeb2fede84eb4fac37f3f28fd22d5761c8390b875",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6"
+        ],
+        "expected_targets": [16, 17, 18, 19, 26],
+        "expected_cached_hashes": [
+            "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+            "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879",
+            "e7cf46a078fed4fafd0b5e3aff144802b853f8ae459a4f0c14add3314b7cc3a6"
+        ]
+    },
+    {
+        "update": {
+            "adds": [6, 7, 8],
+            "proof": {
+                "targets": [4, 5],
+                "hashes": []
+            },
+            "del_hashes": [
+                "e52d9c508c502347344d8c07ad91cbd6068afc75ff6292f062a09ca381c89e71",
+                "e77b9a9ae9e30b0dbdb6f510a264ef9de781501d7b6b92ae89eb059c5ab743db"
+            ]
+        },
+        "remembers": [1],
+        "cached_proof": {
+            "targets": [3],
+            "hashes": [
+                "dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986",
+                "02242b37d8e851f1e86f46790298c7097df06893d6226b7c1453c213e91717de"
+            ]
+        },
+        "initial_stump": "Add 6 leaves [0, 1, 2, 3, 4, 5], then delete [4, 5] and add [6, 7, 8]",
+        "initial_roots": [
+            "df46b17be5f66f0750a4b3efa26d4679db170a72d41eb56c3e4ff75a58c65386",
+            "9eec588c41d87b16b0ee226cb38da3864f9537632321d8be855a73d5616dcc73"
+        ],
+        "initial_leaves": 6,
+        "cached_hashes": [
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5"
+        ],
+        "expected_roots": [
+            "0f1ff6dc2fc7cf8e27236d51de9af7d32adf10a94eef498e167d5e7cf98b0112",
+            "beead77994cf573341ec17b58bbf7eb34d2711c993c1d976b128b3188dc1829a"
+        ],
+        "expected_targets": [3, 19],
+        "expected_cached_hashes": [
+            "084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5",
+            "ca358758f6d27e6cf45272937977a748fd88391db679ceda7dc7bf1f005ee879"
+        ]
+    }
+
+]


### PR DESCRIPTION
This PR finishes the required steps for #12. Now it's possible to update a proof independently given a set of addition and deletions from a block.