### PR TITLE
Refactor: Optimize roots_to_destroy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +103,7 @@ name = "rustreexo"
 version = "0.1.0"
 dependencies = [
  "bitcoin_hashes",
+ "lazy_static",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bitcoin_hashes = "0.11.0"
+lazy_static = "1.4.0"
 sha2 = "0.10.2"
 
 [dev-dependencies]


### PR DESCRIPTION
**Chasing conceptual review on using lazy-static**
`roots_to_destroy` uses a non-zero hash as a marker, holding a root position that doesn't exist. We accomplish this by calling Hash::from_hex() and 0x01 as a 32-byte vector. However, from_hex involves expensive string parsing. After some testing[1], I found this function using more than 60% of cpu time while updating an accumulator.

This PR solves it by introducing a lazy global variable that contains this hash already, so we don't have to compute it over and over

[1] https://github.com/Davidson-Souza/dotfiles/blob/main/utreexo-wallet-flamegraph12212022.svg
