### PR TITLE
Feature/proof subset

### DIFF
--- a/src/accumulator/stump.rs
+++ b/src/accumulator/stump.rs
@@ -56,7 +56,7 @@ impl Stump {
         proof: &Proof,
     ) -> Result<(Stump, UpdateData), String> {
         let mut root_candidates = proof
-            .calculate_hashes(del_hashes, self)?
+            .calculate_hashes(del_hashes, self.leafs)?
             .1
             .into_iter()
             .rev()
@@ -126,7 +126,7 @@ impl Stump {
         }
 
         let del_hashes = vec![sha256::Hash::all_zeros(); proof.targets()];
-        proof.calculate_hashes(&del_hashes, self)
+        proof.calculate_hashes(&del_hashes, self.leafs)
     }
     /// Adds new leafs into the root
     fn add(

--- a/src/accumulator/util.rs
+++ b/src/accumulator/util.rs
@@ -333,9 +333,9 @@ fn is_sibling(a: u64, b: u64) -> bool {
 }
 /// Returns which node should have its hashes on the proof, along with all nodes
 /// whose hashes will be calculated to reach a root
-pub fn get_proof_positions(targets: &Vec<u64>, num_leaves: u64, forest_rows: u8) -> Vec<u64> {
+pub fn get_proof_positions(targets: &[u64], num_leaves: u64, forest_rows: u8) -> Vec<u64> {
     let mut proof_positions = vec![];
-    let mut computed_positions = targets.clone();
+    let mut computed_positions: Vec<_> = targets.iter().copied().collect();
     computed_positions.sort();
 
     for row in 0..=forest_rows {


### PR DESCRIPTION
This method takes a valid proof over a set of elements `s`, a subset `s'` of `s` and returns only the elements needed to prove `s'`, without needing any additional data. This is useful for cached proofs, that involves multiple UTXOs that you may only spend a subset of when creating a transaction.