### PR TITLE
Add linting to the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,42 +10,46 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  Tests:
-    name: Tests
+  build:
+
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - rust: stable
-            env:
-              DO_COV: true
-              DO_LINT: true
-              AS_DEPENDENCY: true
-              DO_NO_STD: true
-          - rust: beta
-            env:
-              AS_DEPENDENCY: true
-              DO_NO_STD: true
-          - rust: nightly
-            env:
-              DO_BENCH: true
-              AS_DEPENDENCY: true
-              DO_NO_STD: true
-              DO_DOCS: true
-          - rust: 1.41.1
-            env:
-              AS_DEPENDENCY: true
-          - rust: 1.47
-            env:
-              AS_DEPENDENCY: true
-              DO_NO_STD: true
+
     steps:
+    # try to build
     - uses: actions/checkout@v3
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
     - name: Build
       run: cargo build --verbose
+    # run all tests
+    - uses: actions/checkout@v3
     - name: Run tests
       run: cargo test --verbose
+
+  linting:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # cargo fmt
+    - uses: actions/checkout@v3
+    - name: fmt
+      run: cargo fmt --all --check
+
+    # run cargo clippy
+    - uses: actions/checkout@v3
+    - name: Clippy
+      run: cargo clippy --all
+
+  cross-testing:
+    strategy:
+      matrix:
+        rust: [stable, nightly, 1.41]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Cross compile
+        run: cargo test --verbose

--- a/examples/proof-update.rs
+++ b/examples/proof-update.rs
@@ -10,6 +10,8 @@
 //! leaf cached, you can still prove some elements, given a block Proof. CSNs can always prove their
 //! own UTXOs if the can access proofs.
 
+use std::str::FromStr;
+
 use rustreexo::accumulator::{node_hash::NodeHash, proof::Proof, stump::Stump};
 
 fn main() {
@@ -18,7 +20,7 @@ fn main() {
     let utxos = get_utxo_hashes1();
     // Add the UTXOs to the accumulator. update_data is the data we need to update the proof
     // after the accumulator is updated.
-    let (s, update_data) = s.modify(&utxos, &vec![], &Proof::default()).unwrap();
+    let (s, update_data) = s.modify(&utxos, &[], &Proof::default()).unwrap();
     // Create an empty proof, we'll update it to hold our UTXOs
     let p = Proof::default();
     // Update the proof with the UTXOs we added to the accumulator. This proof was initially empty,

--- a/examples/simple-stump-update.rs
+++ b/examples/simple-stump-update.rs
@@ -2,7 +2,7 @@
 //! the roots of the accumulator. It's meant for light clients, that don't need to prove membership
 //! of arbitrary elements. Instead, they only need to verify.
 
-use std::vec;
+use std::{str::FromStr, vec};
 
 use rustreexo::accumulator::{node_hash::NodeHash, proof::Proof, stump::Stump};
 

--- a/src/accumulator/util.rs
+++ b/src/accumulator/util.rs
@@ -9,7 +9,7 @@ pub fn is_root_position(position: u64, num_leaves: u64, forest_rows: u8) -> bool
     let root_present = num_leaves & (1 << row) != 0;
     let root_pos = root_position(num_leaves, row, forest_rows);
 
-    return root_present && root_pos == position;
+    root_present && root_pos == position
 }
 
 // removeBit removes the nth bit from the val passed in. For example, if the 2nd
@@ -23,7 +23,7 @@ pub fn remove_bit(val: u64, bit: u64) -> u64 {
     let lower_mask = !(std::u64::MAX ^ mask);
     let lower = val & lower_mask;
 
-    ((upper >> 1) | lower) as u64
+    (upper >> 1) | lower
 }
 pub fn calc_next_pos(position: u64, del_pos: u64, forest_rows: u8) -> Result<u64, String> {
     let del_row = detect_row(del_pos, forest_rows);
@@ -47,14 +47,14 @@ pub fn calc_next_pos(position: u64, del_pos: u64, forest_rows: u8) -> Result<u64
     Ok(higher_bits | lower_bits)
 }
 pub fn detwin(nodes: Vec<u64>, forest_rows: u8) -> Vec<u64> {
-    let mut dels_after = nodes.clone();
+    let mut dels_after = nodes;
     let mut n = 0;
 
     while (n + 1) < dels_after.len() {
         // If the next node in line is the current node's sibling
         // grab the parent as well
-        let i = dels_after[(n) as usize];
-        let j = dels_after[(n + 1) as usize];
+        let i = dels_after[n];
+        let j = dels_after[n + 1];
 
         if is_right_sibling(i, j) {
             dels_after.drain(n..n + 2);
@@ -125,7 +125,7 @@ pub fn detect_row(pos: u64, forest_rows: u8) -> u8 {
         h += 1;
     }
 
-    return h;
+    h
 }
 
 pub fn detect_offset(pos: u64, num_leaves: u64) -> (u8, u8, u64) {
@@ -170,7 +170,7 @@ pub fn detect_offset(pos: u64, num_leaves: u64) -> (u8, u8, u64) {
         tr -= 1;
     }
 
-    return (bigger_trees, tr - nr, !marker);
+    (bigger_trees, tr - nr, !marker)
 }
 
 // parent returns the parent position of the passed in child
@@ -243,14 +243,16 @@ fn is_sibling(a: u64, b: u64) -> bool {
 /// whose hashes will be calculated to reach a root
 pub fn get_proof_positions(targets: &[u64], num_leaves: u64, forest_rows: u8) -> Vec<u64> {
     let mut proof_positions = vec![];
-    let mut computed_positions: Vec<_> = targets.iter().copied().collect();
+    let mut computed_positions = targets.to_vec();
     computed_positions.sort();
 
     for row in 0..=forest_rows {
         let mut row_targets = computed_positions
-            .to_owned()
-            .into_iter()
+            .iter()
+            .copied()
             .filter(|x| super::util::detect_row(*x, forest_rows) == row)
+            .collect::<Vec<_>>()
+            .into_iter()
             .peekable();
 
         while let Some(node) = row_targets.next() {
@@ -282,13 +284,13 @@ pub fn get_proof_positions(targets: &[u64], num_leaves: u64, forest_rows: u8) ->
 mod tests {
     use super::roots_to_destroy;
     use crate::accumulator::{node_hash::NodeHash, util::tree_rows};
-    use std::vec;
+    use std::{str::FromStr, vec};
 
     #[test]
     fn test_proof_pos() {
         let unsorted = vec![33, 35, 32, 34, 50, 52];
         let sorted = vec![33, 35, 32, 34, 50, 52];
-        let num_leaves = 32 as u64;
+        let num_leaves = 32_u64;
         let num_rows = tree_rows(num_leaves);
 
         // Test that un-sorted targets results in the same result as the sorted vec.
@@ -299,11 +301,10 @@ mod tests {
     }
     #[test]
     fn test_is_sibling() {
-        assert_eq!(super::is_sibling(0, 1), true);
-        assert_eq!(super::is_sibling(1, 0), true);
-
-        assert_eq!(super::is_sibling(1, 2), false);
-        assert_eq!(super::is_sibling(2, 1), false);
+        assert!(super::is_sibling(0, 1));
+        assert!(super::is_sibling(1, 0));
+        assert!(!super::is_sibling(1, 2));
+        assert!(!super::is_sibling(2, 1));
     }
     #[test]
     fn test_root_position() {
@@ -327,7 +328,7 @@ mod tests {
         ];
         let roots = roots
             .iter()
-            .map(|hash| NodeHash::from_str(*hash).unwrap())
+            .map(|hash| NodeHash::from_str(hash).unwrap())
             .collect::<Vec<_>>();
 
         let deleted = roots_to_destroy(1, 15, &roots);
@@ -410,7 +411,7 @@ mod tests {
     #[test]
     fn test_is_root_position() {
         let h = super::is_root_position(14, 8, 3);
-        assert_eq!(h, true);
+        assert!(h);
     }
     #[test]
     fn test_calc_next_pos() {


### PR DESCRIPTION
This PR fixes all `rustfmt` and `clippy` warnings, and adds them to the integrated CI. It also tests the lib in other plataforms, like macOS and windows.