### PR TITLE
Add serialization methods

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
       matrix:
         rust: [stable, nightly, 1.41]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        feature: [default, with-serde]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -52,4 +53,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Cross compile
-        run: cargo test --verbose
+        run: cargo test --verbose --features ${{ matrix.feature }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,7 +44,6 @@ name = "rustreexo"
 version = "0.1.0"
 dependencies = [
  "bitcoin_hashes",
- "lazy_static",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bitcoin_hashes = "0.12.0"
-lazy_static = "1.4.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
+
+[features]
+with-serde = ["serde"]
+default = []
 
 [[example]]
 name = "simple-stump-update"

--- a/src/accumulator/node_hash.rs
+++ b/src/accumulator/node_hash.rs
@@ -39,7 +39,12 @@
 //! ```
 use bitcoin_hashes::{hex, sha256, sha512_256, Hash, HashEngine};
 use std::{convert::TryFrom, fmt::Display, ops::Deref, str::FromStr};
+
+#[cfg(feature = "with-serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 /// NodeHash is a wrapper around a 32 byte array that represents a hash of a node in the tree.
 /// # Example
 /// ```

--- a/src/accumulator/util.rs
+++ b/src/accumulator/util.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 // Rustreexo
 use super::node_hash::NodeHash;
 
@@ -177,7 +179,12 @@ pub fn detect_offset(pos: u64, num_leaves: u64) -> (u8, u8, u64) {
 pub fn parent(pos: u64, forest_rows: u8) -> u64 {
     (pos >> 1) | (1 << forest_rows)
 }
-
+pub fn read_u64<Source: Read>(buf: &mut Source) -> Result<u64, String> {
+    let mut bytes = [0u8; 8];
+    buf.read_exact(&mut bytes)
+        .map_err(|_| "Failed to read u64")?;
+    Ok(u64::from_le_bytes(bytes))
+}
 // tree_rows returns the number of rows given n leaves
 pub fn tree_rows(n: u64) -> u8 {
     if n == 0 {


### PR DESCRIPTION
This PR adds some built-in serialization methods for Proof and Stump. It also adds support to `serde`-based serialization, using the `with-serde` feature.