### PR TITLE
Remove #[derive(Default)] for enum

### DIFF
--- a/src/accumulator/node_hash.rs
+++ b/src/accumulator/node_hash.rs
@@ -57,14 +57,17 @@ use serde::{Deserialize, Serialize};
 /// let hash = NodeHash::new([0; 32]);
 /// assert_eq!(hash.to_string().as_str(), "0000000000000000000000000000000000000000000000000000000000000000");
 /// ```
-#[derive(Default)]
 pub enum NodeHash {
-    #[default]
     Empty,
     Placeholder,
     Some([u8; 32]),
 }
 
+impl Default for NodeHash {
+    fn default() -> Self {
+        NodeHash::Empty
+    }
+}
 impl Deref for NodeHash {
     type Target = [u8; 32];
 


### PR DESCRIPTION
Default Derive macro for enums isn't supported in MSRV. Impl it manually