### PR TITLE
Perf: Fix a bottleneck in `calculate_hashes`

### DIFF
--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -1164,10 +1164,31 @@ mod tests {
 #[cfg(bench)]
 mod bench {
     extern crate test;
-    use super::Stump;
+    use crate::accumulator::stump::Stump;
     use crate::accumulator::{proof::Proof, util::hash_from_u8};
     use test::Bencher;
+    #[bench]
+    fn bench_calculate_hashes(bencher: &mut Bencher) {
+        let preimages = 0..255_u8;
+        let utxos = preimages
+            .into_iter()
+            .map(|preimage| hash_from_u8(preimage))
+            .collect::<Vec<_>>();
 
+        let (stump, modified) = Stump::new().modify(&utxos, &[], &Proof::default()).unwrap();
+        let proof = Proof::default();
+        let (proof, cached_hashes) = proof
+            .update(
+                vec![],
+                utxos.clone(),
+                vec![],
+                (0..128).into_iter().collect(),
+                modified,
+            )
+            .unwrap();
+
+        bencher.iter(|| proof.calculate_hashes(&cached_hashes, stump.leaves))
+    }
     #[bench]
     fn bench_proof_update(bencher: &mut Bencher) {
         let preimages = [0_u8, 1, 2, 3, 4, 5];

--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -679,8 +679,10 @@ impl Proof {
         Ok(new_positions)
     }
     fn sorted_push(nodes: &mut Vec<(u64, NodeHash)>, to_add: (u64, NodeHash)) {
-        nodes.push(to_add);
-        nodes.sort();
+        let pos = nodes
+            .binary_search_by(|(pos, _)| pos.cmp(&to_add.0))
+            .unwrap_or_else(|x| x);
+        nodes.insert(pos, to_add);
     }
 }
 


### PR DESCRIPTION
After profiling [Floresta](https://github.com/Davidson-Souza/floresta) I found that `calculate_hashes`, a method used for computing roots from a proof, was taking an absurd amount of time in one specific function called `sorted_push`. As the name implies, this function adds an element to a collection, and keeps the full collection sorted. The approach used was simply to push and then sort the array. But the successive calls to merge-sort caused a severe performance hit for large proofs.

This PR uses an elementary replacement for this function. We keep the invariant of sorting by appending the element right where it should be, if we want to keep the whole collection sorted. We find this element by performing a binary search over the collection.

For reference, I wrote a small [doc](https://github.com/Davidson-Souza/dotfiles/blob/main/utreexo-wallet-benchs/rustreexo-sorting.md) with different approaches that could be taken. The mentioned profiling is this [flamegraph](https://github.com/Davidson-Souza/dotfiles/blob/main/utreexo-wallet-benchs/floresta-flamegraph-20182023.svg). [Here](https://github.com/Davidson-Souza/dotfiles/blob/main/utreexo-wallet-benchs/floresta-flamegraph-13092023.svg)'s how it looks like after this change. This pr also adds a benchmark for this method. Here's the result before and after it.

```
test accumulator::proof::bench::bench_calculate_hashes ... bench:      83,043 ns/iter (+/- 9,842)
```
```
test accumulator::proof::bench::bench_calculate_hashes ... bench:      57,712 ns/iter (+/- 1,221)
```