### PR TITLE
parent_many: force a constant to u64

### DIFF
--- a/src/accumulator/util.rs
+++ b/src/accumulator/util.rs
@@ -233,7 +233,7 @@ pub fn parent_many(pos: u64, rise: u8, forest_rows: u8) -> Result<u64, String> {
             rise, forest_rows
         ));
     }
-    let mask = ((2 << forest_rows) - 1) as u64;
+    let mask = ((2_u64 << forest_rows) - 1) as u64;
     Ok((pos >> rise | (mask << (forest_rows - (rise - 1)) as u64)) & mask)
 }
 


### PR DESCRIPTION
By default, in 64 bits machine rustc will interpret constants as u32, but in parent_many we left shift a constant by the depth of the forest, which can be grather than 32. This would a 32-bits value to be left-shifted by more than 32. This is undefined behavour and should be avoided.

This commit coerces the constants to u64, making it safe shift up to 63. Since tree with depth 63 would be impossible to see in practice (it would represent quadrilions of leaves), there's no risk of having the same UB now.