### PR TITLE
bump msrv to 1.63.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,55 +10,38 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    # try to build
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    # run all tests
-    - uses: actions/checkout@v3
-    - name: Run tests
-      run: cargo test --verbose
 
   linting:
-
     runs-on: ubuntu-latest
-    steps:
-    # Install Rust nightly toolchain
-    - uses: actions/checkout@v3
-    - name: Install nightly toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: nightly
-        override: true
-    
-    # cargo fmt
-    - uses: actions/checkout@v3
-    - name: fmt
-      run: cargo +nightly fmt --all --check
 
-    # run cargo clippy
-    - uses: actions/checkout@v3
-    - name: Clippy
-      run: cargo +nightly clippy --all
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        run: cargo +nightly fmt --all --check
+
+      - name: Run cargo clippy
+        run: cargo +nightly clippy --all-targets
 
   cross-testing:
     strategy:
       matrix:
-        rust: [stable, nightly, 1.41]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        feature: [default, with-serde]
+        toolchain: [nightly, stable, 1.63.0]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
+ 
+      - name: Run Tests
+        run: cargo +${{ matrix.toolchain }} test --all
 
-      - name: Cross compile
-        run: cargo test --verbose --features ${{ matrix.feature }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 repository = "https://github.com/mit-dci/rustreexo"
 readme = "README.md"
 homepage = "https://github.com/mit-dci/rustreexo"
+rust-version = "1.63.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -17,7 +18,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
-starknet-crypto = "0.7.2"
 
 [features]
 with-serde = ["serde"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.63.0"
+components = [ "rustfmt", "clippy" ]
+profile = "default"

--- a/src/accumulator/pollard.rs
+++ b/src/accumulator/pollard.rs
@@ -534,7 +534,7 @@ impl<Hash: AccumulatorHash> Pollard<Hash> {
 
     /// Creates a new empty [Pollard]
     pub fn new() -> Pollard<Hash> {
-        let roots: [Option<Rc<PollardNode<Hash>>>; 64] = [const { None }; 64];
+        let roots: [Option<Rc<PollardNode<Hash>>>; 64] = std::array::from_fn(|_| None);
         Pollard::<Hash> { roots, leaves: 0 }
     }
 }
@@ -849,7 +849,10 @@ impl<Hash: AccumulatorHash> Pollard<Hash> {
             // my parent is a root, I'm a root now
             for i in 0..64 {
                 let aunt = node.aunt().unwrap();
-                let Some(root) = self.roots[i].as_ref() else {
+
+                let root = if let Some(root) = self.roots[i].as_ref() {
+                    root
+                } else {
                     continue;
                 };
                 if root.hash() == aunt.hash() {

--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -462,13 +462,9 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
         let mut computed = Vec::with_capacity(nodes.len() * 2);
         let mut computed_index = 0;
         let mut provided_index = 0;
-        loop {
-            let Some((next_pos, (next_hash_old, next_hash_new))) =
-                Self::get_next(&computed, &nodes, &mut computed_index, &mut provided_index)
-            else {
-                break;
-            };
-
+        while let Some((next_pos, (next_hash_old, next_hash_new))) =
+            Self::get_next(&computed, &nodes, &mut computed_index, &mut provided_index)
+        {
             if util::is_root_position(next_pos, num_leaves, total_rows) {
                 calculated_root_hashes.push((next_hash_old, next_hash_new));
                 continue;
@@ -547,13 +543,10 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
         let mut computed = Vec::with_capacity(nodes.len() * 2);
         let mut computed_index = 0;
         let mut provided_index = 0;
-        loop {
-            let Some((next_pos, next_hash)) =
-                Self::get_next(&computed, &nodes, &mut computed_index, &mut provided_index)
-            else {
-                break;
-            };
 
+        while let Some((next_pos, next_hash)) =
+            Self::get_next(&computed, &nodes, &mut computed_index, &mut provided_index)
+        {
             if util::is_root_position(next_pos, num_leaves, total_rows) {
                 calculated_root_hashes.push(next_hash);
                 continue;

--- a/src/accumulator/stump.rs
+++ b/src/accumulator/stump.rs
@@ -389,6 +389,7 @@ mod test {
             }
             fn parent_hash(left: &Self, right: &Self) -> Self {
                 let mut hash = [0; 32];
+                #[allow(clippy::needless_range_loop)]
                 for i in 0..32 {
                     hash[i] = left.0[i] ^ right.0[i];
                 }


### PR DESCRIPTION
This is the same MSRV used by rust-bitcoin, and required to build the latest bitcoin-hashes.

This commit does the following:
  - Creates a rust-toolchain.toml with our msrv
  - Adds the rust-version attribute to Cargo.toml
  - Makes some changes to make sure our code builds on 0.63.0