### PR TITLE
[bug fix] write roots len as 64-representation always

### DIFF
--- a/src/accumulator/mem_forest.rs
+++ b/src/accumulator/mem_forest.rs
@@ -255,7 +255,7 @@ impl<Hash: AccumulatorHash> MemForest<Hash> {
     /// ```
     pub fn serialize<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
         writer.write_all(&self.leaves.to_le_bytes())?;
-        writer.write_all(&self.roots.len().to_le_bytes())?;
+        writer.write_all(&(self.roots.len() as u64).to_le_bytes())?;
 
         for root in &self.roots {
             root.write_one(&mut writer).unwrap();

--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -370,12 +370,12 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
     /// ```
     pub fn serialize<W: Write>(&self, mut writer: W) -> std::io::Result<usize> {
         let mut len = 16;
-        writer.write_all(&self.targets.len().to_le_bytes())?;
+        writer.write_all(&(self.targets.len() as u64).to_le_bytes())?;
         for target in &self.targets {
             len += 8;
             writer.write_all(&target.to_le_bytes())?;
         }
-        writer.write_all(&self.hashes.len().to_le_bytes())?;
+        writer.write_all(&(self.hashes.len() as u64).to_le_bytes())?;
         for hash in &self.hashes {
             len += 32;
             hash.write(&mut writer)?;

--- a/src/accumulator/stump.rs
+++ b/src/accumulator/stump.rs
@@ -107,7 +107,7 @@ impl Stump {
     pub fn serialize<Dst: Write>(&self, mut writer: &mut Dst) -> std::io::Result<usize> {
         let mut len = 8;
         writer.write_all(&self.leaves.to_le_bytes())?;
-        writer.write_all(&self.roots.len().to_le_bytes())?;
+        writer.write_all(&(self.roots.len() as u64).to_le_bytes())?;
         for root in self.roots.iter() {
             len += 32;
             root.write(&mut writer)?;


### PR DESCRIPTION
On 32-bit platform usize would be written as 32-bit little endian, and
fail to be read during deserialization (was expecting 64-bit).