### PR TITLE
stump: add proper error handling

### DIFF
--- a/src/accumulator/mem_forest.rs
+++ b/src/accumulator/mem_forest.rs
@@ -411,7 +411,7 @@ impl<Hash: AccumulatorHash> MemForest<Hash> {
         if let (Some(node), Some(sibling), Some(parent)) = (n, sibling, parent) {
             return Ok((node, sibling, parent));
         }
-        Err(format!("node {} not found", pos))
+        Err(format!("node {pos} not found"))
     }
 
     fn del(&mut self, targets: &[Hash]) -> Result<(), String> {
@@ -434,7 +434,7 @@ impl<Hash: AccumulatorHash> MemForest<Hash> {
                     self.del_single(&target.upgrade().unwrap());
                 }
                 None => {
-                    return Err(format!("node {} not in the forest", target));
+                    return Err(format!("node {target} not in the forest"));
                 }
             }
         }

--- a/src/accumulator/node_hash.rs
+++ b/src/accumulator/node_hash.rs
@@ -116,9 +116,9 @@ impl Display for BitcoinNodeHash {
         if let BitcoinNodeHash::Some(ref inner) = self {
             let mut s = String::new();
             for byte in inner.iter() {
-                s.push_str(&format!("{:02x}", byte));
+                s.push_str(&format!("{byte:02x}"));
             }
-            write!(f, "{}", s)
+            write!(f, "{s}")
         } else {
             write!(f, "empty")
         }
@@ -133,9 +133,9 @@ impl Debug for BitcoinNodeHash {
             BitcoinNodeHash::Some(ref inner) => {
                 let mut s = String::new();
                 for byte in inner.iter() {
-                    s.push_str(&format!("{:02x}", byte));
+                    s.push_str(&format!("{byte:02x}"));
                 }
-                write!(f, "{}", s)
+                write!(f, "{s}")
             }
         }
     }

--- a/src/accumulator/pollard.rs
+++ b/src/accumulator/pollard.rs
@@ -179,10 +179,10 @@ impl<Hash: AccumulatorHash> PartialEq for PollardError<Hash> {
 impl<Hash: AccumulatorHash> Debug for PollardError<Hash> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PollardError::NodeNotFound(hash) => write!(f, "Node not found: {}", hash),
-            PollardError::PositionNotFound(pos) => write!(f, "Position not found: {}", pos),
+            PollardError::NodeNotFound(hash) => write!(f, "Node not found: {hash}"),
+            PollardError::PositionNotFound(pos) => write!(f, "Position not found: {pos}"),
             PollardError::InvalidProof => write!(f, "Invalid proof"),
-            PollardError::IO(err) => write!(f, "IO error: {}", err),
+            PollardError::IO(err) => write!(f, "IO error: {err}"),
             PollardError::CouldNotUpgradeNode => {
                 write!(f, "Could not upgrade node, this is probably a bug")
             }
@@ -199,7 +199,7 @@ impl<Hash: AccumulatorHash> Debug for PollardError<Hash> {
 
 impl<Hash: AccumulatorHash> std::fmt::Display for PollardError<Hash> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -397,18 +397,22 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
     /// assert_eq!(Proof::default(), deserialized_proof);
     /// ```
     pub fn deserialize<Source: Read>(mut buf: Source) -> Result<Self, String> {
-        let targets_len = read_u64(&mut buf)? as usize;
+        let targets_len =
+            read_u64(&mut buf).map_err(|reason| format!("io error {reason}"))? as usize;
 
         let mut targets = Vec::with_capacity(targets_len);
         for _ in 0..targets_len {
             targets.push(read_u64(&mut buf).map_err(|_| "Failed to parse target")?);
         }
-        let hashes_len = read_u64(&mut buf)? as usize;
+
+        let hashes_len =
+            read_u64(&mut buf).map_err(|reason| format!("io error {reason}"))? as usize;
         let mut hashes = Vec::with_capacity(hashes_len);
         for _ in 0..hashes_len {
             let hash = Hash::read(&mut buf).map_err(|_| "Failed to parse hash")?;
             hashes.push(hash);
         }
+
         Ok(Proof { targets, hashes })
     }
 

--- a/src/accumulator/proof.rs
+++ b/src/accumulator/proof.rs
@@ -477,10 +477,10 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
             let sibling = next_pos | 1;
             let (sibling_pos, (sibling_hash_old, sibling_hash_new)) =
                 Self::get_next(&computed, &nodes, &mut computed_index, &mut provided_index)
-                    .ok_or(format!("Missing sibling for {}", next_pos))?;
+                    .ok_or(format!("Missing sibling for {next_pos}"))?;
 
             if sibling_pos != sibling {
-                return Err(format!("Missing sibling for {}", next_pos));
+                return Err(format!("Missing sibling for {next_pos}"));
             }
 
             let parent_hash = match (next_hash_new.is_empty(), sibling_hash_new.is_empty()) {
@@ -559,10 +559,10 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
             let sibling = next_pos | 1;
             let (sibling_pos, sibling_hash) =
                 Self::get_next(&computed, &nodes, &mut computed_index, &mut provided_index)
-                    .ok_or(format!("Missing sibling for {}", next_pos))?;
+                    .ok_or(format!("Missing sibling for {next_pos}"))?;
 
             if sibling_pos != sibling {
-                return Err(format!("Missing sibling for {}", next_pos));
+                return Err(format!("Missing sibling for {next_pos}"));
             }
 
             let parent_hash = AccumulatorHash::parent_hash(&next_hash, &sibling_hash);
@@ -716,7 +716,7 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
                 // This node must be in either new_nodes or in the old proof, otherwise we can't
                 // update our proof
                 if !new_proof.iter().any(|(proof_pos, _)| *proof_pos == pos) {
-                    return Err(format!("Missing position {}", pos));
+                    return Err(format!("Missing position {pos}"));
                 }
             }
         }

--- a/src/accumulator/stump.rs
+++ b/src/accumulator/stump.rs
@@ -170,9 +170,9 @@ impl<Hash: AccumulatorHash> Stump<Hash> {
     /// deleted from the accumulator.
     /// // TODO: Add example
     pub fn verify(&self, proof: &Proof<Hash>, del_hashes: &[Hash]) -> Result<bool, StumpError> {
-        Ok(proof
+        proof
             .verify(del_hashes, &self.roots, self.leaves)
-            .map_err(|error| StumpError::InvalidProof(error))?)
+            .map_err(StumpError::InvalidProof)
     }
 
     /// Creates a new Stump with a custom hash type
@@ -307,9 +307,9 @@ impl<Hash: AccumulatorHash> Stump<Hash> {
             .map(|hash| (*hash, Hash::empty()))
             .collect::<Vec<_>>();
 
-        Ok(proof
+        proof
             .calculate_hashes_delete(&del_hashes, self.leaves)
-            .map_err(|reason| StumpError::InvalidProof(reason))?)
+            .map_err(StumpError::InvalidProof)
     }
 
     /// Adds new leaves into the root

--- a/src/accumulator/util.rs
+++ b/src/accumulator/util.rs
@@ -35,8 +35,7 @@ pub fn calc_next_pos(position: u64, del_pos: u64, forest_rows: u8) -> Result<u64
 
     if del_row < pos_row {
         return Err(format!(
-            "calc_next_pos fail: del_pos of {} is at a lower row than position at {}",
-            del_pos, position
+            "calc_next_pos fail: del_pos of {del_pos} is at a lower row than position at {position}"
         ));
     }
 
@@ -73,7 +72,7 @@ pub fn detwin(nodes: Vec<u64>, forest_rows: u8) -> Vec<u64> {
         if next == sibling {
             let parent = parent(node, forest_rows);
 
-            if let Err(_) = computed.binary_search(&parent) {
+            if computed.binary_search(&parent).is_err() {
                 computed.push(parent);
             }
 
@@ -255,8 +254,7 @@ pub fn parent_many(pos: u64, rise: u8, forest_rows: u8) -> Result<u64, String> {
     }
     if rise > forest_rows {
         return Err(format!(
-            "Cannot rise more than the forestRows: rise: {} forest_rows: {}",
-            rise, forest_rows
+            "Cannot rise more than the forestRows: rise: {rise} forest_rows: {forest_rows}"
         ));
     }
 

--- a/src/accumulator/util.rs
+++ b/src/accumulator/util.rs
@@ -223,12 +223,13 @@ pub fn max_position_at_row(row: u8, total_rows: u8, num_leaves: u64) -> Result<u
 pub fn parent(pos: u64, forest_rows: u8) -> u64 {
     (pos >> 1) | (1 << forest_rows)
 }
-pub fn read_u64<Source: Read>(buf: &mut Source) -> Result<u64, String> {
+
+pub fn read_u64<Source: Read>(buf: &mut Source) -> Result<u64, std::io::Error> {
     let mut bytes = [0u8; 8];
-    buf.read_exact(&mut bytes)
-        .map_err(|_| "Failed to read u64")?;
+    buf.read_exact(&mut bytes)?;
     Ok(u64::from_le_bytes(bytes))
 }
+
 // tree_rows returns the number of rows given n leaves
 pub fn tree_rows(n: u64) -> u8 {
     if n == 0 {
@@ -280,16 +281,6 @@ pub fn is_ancestor(higher_pos: u64, lower_pos: u64, forest_rows: u8) -> Result<b
     let ancestor = parent_many(lower_pos, higher_row - lower_row, forest_rows)?;
 
     Ok(higher_pos == ancestor)
-}
-
-/// Returns whether next is node's sibling or not
-pub fn is_right_sibling(node: u64, next: u64) -> bool {
-    node | 1 == next
-}
-
-/// Returns whether a and b are sibling or not
-fn is_sibling(a: u64, b: u64) -> bool {
-    a ^ 1 == b
 }
 
 /// Returns which node should have its hashes on the proof, along with all nodes
@@ -374,25 +365,12 @@ mod tests {
     }
 
     #[test]
-    fn test_is_sibling() {
-        assert!(super::is_sibling(0, 1));
-        assert!(super::is_sibling(1, 0));
-        assert!(!super::is_sibling(1, 2));
-        assert!(!super::is_sibling(2, 1));
-    }
-
-    #[test]
     fn test_root_position() {
         let pos = super::root_position(5, 2, 3);
         assert_eq!(pos, 12);
 
         let pos = super::root_position(5, 0, 3);
         assert_eq!(pos, 4);
-    }
-
-    #[test]
-    fn test_is_right_sibling() {
-        assert!(super::is_right_sibling(0, 1));
     }
 
     #[test]


### PR DESCRIPTION
In continuation to https://github.com/mit-dci/rustreexo/pull/69, this commit adds proper error
handling to `Stump`. Rather than returning a String as error,
we now have an enum that lists all possible errors.