### PR TITLE
Bump `bitcoin-io` to v0.5.0 and bump CI deps

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup toolchain install stable --no-self-update
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
         run: rustup toolchain install stable --component clippy,rustfmt --no-self-update
 
       - name: Configure Rust cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.os }}-benchmark-stable
           cache-on-failure: true
@@ -210,7 +210,7 @@ jobs:
           echo "Run number: ${{ github.run_number }}" >> artifacts/archive-info.txt
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: benchmark-results-${{ matrix.os }}-${{ github.run_number }}
           path: artifacts/
@@ -218,7 +218,7 @@ jobs:
           compression-level: 6
 
       - name: Upload HTML reports
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: benchmark-html-reports-${{ matrix.os }}-${{ github.run_number }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         run: rustup toolchain install nightly --component clippy,rustfmt --no-self-update
 
       - name: Setup just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - name: Run just check
         run: just check
@@ -41,7 +41,7 @@ jobs:
         run: rustup toolchain install 1.74.0 --no-self-update
 
       - name: Setup just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - name: Run MSRV tests
         run: just test-msrv
@@ -67,7 +67,7 @@ jobs:
         run: rustc +${{ matrix.toolchain }} -Vv
 
       - name: Setup just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - name: Run Tests
         run: just test-${{ matrix.toolchain }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitcoin_hashes = { version = "0.20", default-features = false }
 hex-conservative = { version = "1.0.0", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 hashbrown = "0.16.1"
-bitcoin-io = { version = "0.3.0", default-features = false, features = ["alloc"] }
+bitcoin-io = { version = "0.5.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Overrides #107
Overrides #108 
Overrides #109
Overrides #110

## Changelog
```
- Bump `bitcoin-io` from v0.3.0 to v0.5.0
- Bump `extractions/setup-just` from v3.0.0 to v3.1.0
- Bump `actions/upload-artifact` from v6.0.0 to v7.0.0
- Bump `Swatinem/rust-cache` from v2.8.2 to v2.9.1
```