### PR TITLE
chore: Bump dependencies

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -210,7 +210,7 @@ jobs:
           echo "Run number: ${{ github.run_number }}" >> artifacts/archive-info.txt
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results-${{ matrix.os }}-${{ github.run_number }}
           path: artifacts/
@@ -218,7 +218,7 @@ jobs:
           compression-level: 6
 
       - name: Upload HTML reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: benchmark-html-reports-${{ matrix.os }}-${{ github.run_number }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         run: rustup toolchain install nightly --component clippy,rustfmt --no-self-update
 
       - name: Setup just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
       - name: Run just check
         run: just check
@@ -41,7 +41,7 @@ jobs:
         run: rustup toolchain install 1.74.0 --no-self-update
 
       - name: Setup just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
       - name: Run MSRV tests
         run: just test-msrv
@@ -67,7 +67,7 @@ jobs:
         run: rustc +${{ matrix.toolchain }} -Vv
 
       - name: Setup just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
       - name: Run Tests
         run: just test-${{ matrix.toolchain }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor
         run: uvx zizmor .

--- a/src/mem_forest/mod.rs
+++ b/src/mem_forest/mod.rs
@@ -640,7 +640,7 @@ impl<Hash: AccumulatorHash> MemForest<Hash> {
                         Ok(val) => {
                             if pos >= 100 {
                                 output[h as usize * 2].push_str(
-                                    format!("{:#02x}:{} ", pos, &val.to_string()[..2]).as_str(),
+                                    format!("{:x}:{} ", pos, &val.to_string()[..2]).as_str(),
                                 );
                             } else {
                                 output[h as usize * 2].push_str(

--- a/src/pollard/mod.rs
+++ b/src/pollard/mod.rs
@@ -1038,7 +1038,7 @@ impl<Hash: AccumulatorHash> Pollard<Hash> {
                         Ok(val) => {
                             if pos >= 100 {
                                 output[h as usize * 2].push_str(
-                                    format!("{:#02x}:{} ", pos, &val.to_string()[..2]).as_str(),
+                                    format!("{:x}:{} ", pos, &val.to_string()[..2]).as_str(),
                                 );
                             } else {
                                 output[h as usize * 2].push_str(


### PR DESCRIPTION
Hashbrown can't be bumped to the latest 0.17.0 due to MSRV incompatibilities.

### Changelog

```
chore(deps): bump astral-sh/setup-uv from 7.1.6 to 8.1.0
chore(deps): bump actions/upload-artifact from 7.0.0 to 7.0.1
chore(deps): bump extractions/setup-just from 3.1.0 to 4.0.0
```
