### PR TITLE
Bump RBMT to v0.2.1

### DIFF
--- a/.github/actions/setup-rbmt/action.yml
+++ b/.github/actions/setup-rbmt/action.yml
@@ -1,0 +1,31 @@
+name: Setup cargo-rbmt
+
+description: Install cargo-rbmt
+
+inputs:
+  rbmt-version:
+    description: "Git ref (commit, tag, or branch) of cargo-rbmt to install. If not provided, reads from rbmt-version file in repo root, or falls back to master"
+    required: false
+  repo-url:
+    description: "Git repository URL to install cargo-rbmt from. Defaults to the primary upstream repository"
+    required: false
+    default: 'https://git.rust-bitcoin.org/rust-bitcoin/rust-bitcoin-maintainer-tools'
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Install cargo-rbmt
+      shell: bash
+      env:
+        RBMT_VERSION: ${{ inputs.rbmt-version }}
+        REPO_URL: ${{ inputs.repo-url }}
+      run: |
+        [ -z "$RBMT_VERSION" ] && [ -f rbmt-version ] && RBMT_VERSION=$(cat rbmt-version)
+        [ -z "$RBMT_VERSION" ] && RBMT_VERSION=master
+        [ -z "$REPO_URL" ] && REPO_URL='https://git.rust-bitcoin.org/rust-bitcoin/rust-bitcoin-maintainer-tools'
+        cargo install --git "$REPO_URL" --rev "$RBMT_VERSION" cargo-rbmt --locked
+
+    - name: Install Rust Toolchains
+      shell: bash
+      run: cargo rbmt toolchains

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
             - name: Setup cargo-rbmt
-              uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
+              uses: ./.github/actions/setup-rbmt
 
             - name: Display system and commit information
               env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
             - name: Setup cargo-rbmt
-              uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
+              uses: ./.github/actions/setup-rbmt
 
             - name: Run ${{ matrix.task }}
               run: cargo rbmt ${{ matrix.task }}
@@ -53,7 +53,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
             - name: Setup cargo-rbmt
-              uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
+              uses: ./.github/actions/setup-rbmt
 
             - name: Run tests
               run: cargo rbmt test --toolchain ${{ matrix.toolchain }} --lock-file ${{ matrix.lockfile }}
@@ -71,7 +71,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
             - name: Setup cargo-rbmt
-              uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
+              uses: ./.github/actions/setup-rbmt
 
             - name: Add no_std target
               run: rustup target add thumbv7m-none-eabi --toolchain 1.74.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ use_self = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bench)'] }
 
 [package.metadata.rbmt.toolchains]
-stable = "1.94.0"
-nightly = "nightly-2026-03-18"
+stable = "1.95.0"
+nightly = "nightly-2026-05-12"
 
 [package.metadata.rbmt.test]
 # Examples to run with different feature configurations.

--- a/README.md
+++ b/README.md
@@ -50,16 +50,19 @@ To see complete usage examples, refer to the [`examples/`](./examples) folder.
 
 ## Developing
 
-This project uses [`cargo-rbmt`](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/tree/master/cargo-rbmt)
-to manage everything related to `cargo`, such as formatting, linting, testing and CI. To install it, run:
+This project uses [`just`](https://github.com/casey/just) for command running, and
+[`cargo-rbmt`](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/tree/master/cargo-rbmt)
+to manage everything related to `cargo`, such as formatting, linting, testing and CI. To install them, run:
 
-```console
+```shell
+~$ cargo install just
+
 ~$ cargo install cargo-rbmt
 ```
 
 A `justfile` is provided for convenience. Run `just` to see available commands:
 
-```console
+```shell
 ~$ just
 > rustreexo
 > A Rust implementation of Utreexo

--- a/examples/custom_hash.rs
+++ b/examples/custom_hash.rs
@@ -1,7 +1,7 @@
 //! All data structures in this library are generic over the hash type used, defaulting to
-//! [BitcoinNodeHash](crate::accumulator::node_hash::BitcoinNodeHash), the one used by Bitcoin
+//! [`BitcoinNodeHash`](rustreexo::node_hash::BitcoinNodeHash), the one used by Bitcoin
 //! as defined by the utreexo spec. However, if you need to use a different hash type, you can
-//! implement the [NodeHash](crate::accumulator::node_hash::NodeHash) trait for it, and use it
+//! implement the [`NodeHash`](rustreexo::node_hash::NodeHash) trait for it, and use it
 //! with the accumulator data structures.
 //!
 //! This example shows how to use a custom hash type based on the Poseidon hash function. The
@@ -9,10 +9,9 @@
 //! for zero-knowledge proofs, and is used in projects like ZCash and StarkNet.
 //! If you want to work with utreexo proofs in zero-knowledge you may want to use this instead
 //! of our usual sha512-256 that we use by default, since that will give you smaller circuits.
-//! This example shows how to use both the [MemForest](crate::accumulator::MemForest::MemForest) and
-//! proofs with a custom hash type. The code here should be pretty much all you need to do to
-//! use your custom hashes, just tweak the implementation of
-//! [NodeHash](crate::accumulator::node_hash::NodeHash) for your hash type.
+//! This example shows how to use both the [`MemForest`] and proofs with a custom hash type.
+//! The code here should be pretty much all you need to do to use your custom hashes, just tweak
+//! the implementation of [`NodeHash`](rustreexo::node_hash::NodeHash) for your hash type.
 
 use rustreexo::mem_forest::MemForest;
 use rustreexo::node_hash::AccumulatorHash;

--- a/justfile
+++ b/justfile
@@ -15,14 +15,13 @@ _default:
 
 [doc: "Run benchmarks: accumulator, proof, stump"]
 bench BENCH="":
-    cargo bench {{ if BENCH != "" { "--bench " + BENCH } else { "" } }}
+    cargo rbmt bench {{ if BENCH != "" { "--bench " + BENCH } else { "" } }}
 
 [doc: "Check code formatting, compilation, and linting"]
 check:
     cargo rbmt fmt --check
     cargo rbmt lint
-    cargo rbmt docs
-    RUSTFLAGS="--cfg=bench" cargo +nightly check --benches
+    cargo rbmt docsrs
 
 [doc: "Checks whether all commits in this branch are signed"]
 check-sigs:
@@ -30,13 +29,11 @@ check-sigs:
 
 [doc: "Generate documentation"]
 doc:
-    cargo rbmt docs
-    cargo doc --no-deps
+    cargo rbmt docsrs
 
 [doc: "Generate and open documentation"]
 doc-open:
-    cargo rbmt docs
-    cargo doc --no-deps --open
+    cargo rbmt docsrs --open
 
 [doc: "Format code"]
 fmt:

--- a/rbmt-version
+++ b/rbmt-version
@@ -1,1 +1,1 @@
-6560b728ae6a81af9d92713b630ba26772fbd970
+cargo-rbmt-0.2.1


### PR DESCRIPTION
Overrides #123 


## Changelog
```
- Bump RBMT to v0.2.1:
  - Add a vendored `setup-rbmt` action
- Update the `justfile`
- Fix doc comment references (`rbmt` v0.2.1 now checks examples)
```