### PR TITLE
Fix broken intra-doc links in the `custom_hash` example

### DIFF
--- a/examples/custom_hash.rs
+++ b/examples/custom_hash.rs
@@ -1,7 +1,7 @@
 //! All data structures in this library are generic over the hash type used, defaulting to
-//! [BitcoinNodeHash](crate::accumulator::node_hash::BitcoinNodeHash), the one used by Bitcoin
+//! [BitcoinNodeHash](rustreexo::node_hash::BitcoinNodeHash), the one used by Bitcoin
 //! as defined by the utreexo spec. However, if you need to use a different hash type, you can
-//! implement the [NodeHash](crate::accumulator::node_hash::NodeHash) trait for it, and use it
+//! implement the [AccumulatorHash] trait for it, and use it
 //! with the accumulator data structures.
 //!
 //! This example shows how to use a custom hash type based on the Poseidon hash function. The
@@ -9,10 +9,10 @@
 //! for zero-knowledge proofs, and is used in projects like ZCash and StarkNet.
 //! If you want to work with utreexo proofs in zero-knowledge you may want to use this instead
 //! of our usual sha512-256 that we use by default, since that will give you smaller circuits.
-//! This example shows how to use both the [MemForest](crate::accumulator::MemForest::MemForest) and
+//! This example shows how to use both the [MemForest] and
 //! proofs with a custom hash type. The code here should be pretty much all you need to do to
 //! use your custom hashes, just tweak the implementation of
-//! [NodeHash](crate::accumulator::node_hash::NodeHash) for your hash type.
+//! [AccumulatorHash] for your hash type.
 
 use rustreexo::mem_forest::MemForest;
 use rustreexo::node_hash::AccumulatorHash;
@@ -29,8 +29,8 @@ enum CustomHash {
     Hash([u8; 32]),
     /// Placeholder is a value that haven't been deleted, but we don't have the actual value.
     /// The only thing that matters about it is that it's not empty. You can implement this
-    /// the way you want, just make sure that [NodeHash::is_placeholder] and [NodeHash::placeholder]
-    /// returns sane values (that is, if we call [NodeHash::placeholder] calling [NodeHash::is_placeholder]
+    /// the way you want, just make sure that [AccumulatorHash::is_placeholder] and [AccumulatorHash::placeholder]
+    /// returns sane values (that is, if we call [AccumulatorHash::placeholder] calling [AccumulatorHash::is_placeholder]
     /// on the result should return true).
     Placeholder,
 
@@ -38,7 +38,7 @@ enum CustomHash {
     /// This is an empty value, it represents a node that was deleted from the accumulator.
     ///
     /// Same as the placeholder, you can implement this the way you want, just make sure that
-    /// [NodeHash::is_empty] and [NodeHash::empty] returns sane values.
+    /// [AccumulatorHash::is_empty] and [AccumulatorHash::empty] returns sane values.
     Empty,
 }
 
@@ -53,7 +53,7 @@ impl std::fmt::Display for CustomHash {
     }
 }
 
-// this is the implementation of the NodeHash trait for our custom hash type. And it's the only
+// this is the implementation of the AccumulatorHash trait for our custom hash type. And it's the only
 // thing you need to do to use your custom hash type with the accumulator data structures.
 impl AccumulatorHash for CustomHash {
     // returns a new placeholder type such that is_placeholder returns true

--- a/examples/custom_hash.rs
+++ b/examples/custom_hash.rs
@@ -108,7 +108,7 @@ impl AccumulatorHash for CustomHash {
         }
     }
 
-    // the main thing about the hash type, it returns the next node's hash, given it's children.
+    // the main thing about the hash type, it returns the next node's hash, given its children.
     // The implementation of this method is highly consensus critical, so everywhere should use the
     // exact same algorithm to calculate the next hash. Rustreexo won't call this method, unless
     // **both** children are not empty.


### PR DESCRIPTION
## Description

`cargo rbmt docs` currently fails locally with the current cargo-rbmt:

```shell
error: unresolved link to `crate::accumulator::node_hash::BitcoinNodeHash`
 --> examples/custom_hash.rs:2:23
  |
2 | //! [BitcoinNodeHash](crate::accumulator::node_hash::BitcoinNodeHash), the one used by Bitcoin
  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `accumulator` in module `custom_hash`
  |
  = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`

error: unresolved link to `crate::accumulator::node_hash::NodeHash`
 --> examples/custom_hash.rs:4:30
  |
4 | //! implement the [NodeHash](crate::accumulator::node_hash::NodeHash) trait for it, and use it
  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `accumulator` in module `custom_hash`

error: unresolved link to `crate::accumulator::MemForest::MemForest`
  --> examples/custom_hash.rs:12:56
   |
12 | //! This example shows how to use both the [MemForest](crate::accumulator::MemForest::MemForest) and
   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `accumulator` in module `custom_hash`

error: unresolved link to `crate::accumulator::node_hash::NodeHash`
  --> examples/custom_hash.rs:15:16
   |
15 | //! [NodeHash](crate::accumulator::node_hash::NodeHash) for your hash type.
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `accumulator` in module `custom_hash`

error: could not document `rustreexo`
warning: build failed, waiting for other jobs to finish...
Error building docs: command exited with non-zero code `cargo --locked doc --all-features --no-deps --examples -p path+file:///home/edu/Documents/Apps/Projects/Neha/rustreexo#0.5.0`: 101
```

The doc links in `examples/custom_hash.rs` use `crate::accumulator::...` paths. 
`crate::` inside an example refers to the example binary, not to `rustreexo`, and the `accumulator` module was removed in #98, so the links can't resolve. 

### Verification

Verified by running `cargo rbmt docs`