### PR TITLE
refactor: improve some error messages for Stump

### DIFF
--- a/examples/proof_update.rs
+++ b/examples/proof_update.rs
@@ -42,7 +42,7 @@ fn main() {
     // Get a subset of the proof, for the first UTXO only
     let p1 = p.get_proof_subset(&cached_hashes, &[0], s.leaves).unwrap();
 
-    assert_eq!(s.verify(&p1, &cached_hashes), Ok(true));
+    assert_eq!(s.verify(&p1, &[cached_hashes[0]]), Ok(true));
 
     // Assume we have a block that (beyond coinbase) spends our UTXO `0` and creates 7 new UTXOs
     // We'll remove `0` as it got spent, and add 1..7 to our cache.

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -91,11 +91,17 @@ pub enum ProofError {
     /// A hash could not be parsed during deserialization.
     InvalidHash,
 
+    /// The computed roots don't match current accumulator.
+    RootsMismatch,
+
     /// A sibling node required to compute the root hash is missing from the proof.
     MissingSibling(u64),
 
     /// A proof hash required to update the proof to a new state is missing.
     MissingProofHash(u64),
+
+    /// Target count must be equal to del hashes
+    DelHashesTargetsMismatch { targets: usize, del_hashes: usize },
 }
 
 impl fmt::Display for ProofError {
@@ -107,6 +113,15 @@ impl fmt::Display for ProofError {
             Self::MissingSibling(pos) => write!(f, "missing sibling for node at position {pos}"),
             Self::MissingProofHash(pos) => {
                 write!(f, "missing proof hash for position {pos}")
+            }
+            Self::DelHashesTargetsMismatch {
+                targets,
+                del_hashes,
+            } => {
+                write!(f, "the number of targets must be equal to del_hashes. targets={targets} del_hashes={del_hashes}")
+            }
+            Self::RootsMismatch => {
+                write!(f, "the computed roots don't match current accumulator.")
             }
         }
     }
@@ -480,6 +495,13 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
         del_hashes: &[(Hash, Hash)],
         num_leaves: u64,
     ) -> Result<NodesAndRootsOldNew<Hash>, ProofError> {
+        if self.targets.len() != del_hashes.len() {
+            return Err(ProofError::DelHashesTargetsMismatch {
+                targets: self.targets.len(),
+                del_hashes: del_hashes.len(),
+            });
+        }
+
         // Where all the root hashes that we've calculated will go to.
         let total_rows = util::tree_rows(num_leaves);
 
@@ -567,6 +589,13 @@ impl<Hash: AccumulatorHash> Proof<Hash> {
         del_hashes: &[Hash],
         num_leaves: u64,
     ) -> Result<NodesAndRootsCurrent<Hash>, ProofError> {
+        if self.targets.len() != del_hashes.len() {
+            return Err(ProofError::DelHashesTargetsMismatch {
+                targets: self.targets.len(),
+                del_hashes: del_hashes.len(),
+            });
+        }
+
         // Where all the root hashes that we've calculated will go to.
         let total_rows = util::tree_rows(num_leaves);
 

--- a/src/stump/mod.rs
+++ b/src/stump/mod.rs
@@ -59,10 +59,6 @@ pub struct UpdateData<Hash: AccumulatorHash> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// The error kinds returned by Stump's methods
 pub enum StumpError {
-    /// User passed in a proof that doesn't have any elements, but a non-zero list of
-    /// targets.
-    EmptyProof,
-
     /// An IO error occurred, this is usually due to a failure in reading or writing
     /// the Stump to a reader/writer. This error will be returned during (de)serialization.
     Io(io::ErrorKind),
@@ -75,7 +71,6 @@ pub enum StumpError {
 impl fmt::Display for StumpError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::EmptyProof => write!(f, "proof has no elements but targets are non-empty"),
             Self::Io(kind) => write!(f, "I/O error: {kind:?}"),
             Self::InvalidProof(e) => write!(f, "invalid proof: {e}"),
         }
@@ -238,11 +233,9 @@ impl<Hash: AccumulatorHash> Stump<Hash> {
 
         for root in self.roots.iter() {
             if let Some(pos) = computed_roots.iter().position(|(old, _new)| old == root) {
-                let (old_root, new_root) = computed_roots.remove(pos);
-                if old_root == *root {
-                    new_roots.push(new_root);
-                    continue;
-                }
+                let (_, new_root) = computed_roots.remove(pos);
+                new_roots.push(new_root);
+                continue;
             }
 
             new_roots.push(*root);
@@ -251,7 +244,7 @@ impl<Hash: AccumulatorHash> Stump<Hash> {
         // If there are still roots to be added, it means that the proof is invalid
         // as we should have consumed all the roots.
         if !computed_roots.is_empty() {
-            return Err(StumpError::EmptyProof);
+            return Err(StumpError::InvalidProof(ProofError::RootsMismatch));
         }
 
         let (roots, updated, destroyed) = Self::add(new_roots, utxos, self.leaves);


### PR DESCRIPTION
We currently use some messages that are hard to debug, or outright wrong. For example, if a proof is invalid because we didn't compute the original rootset, we return `EmptyProof`, which is misleading.

This commit adds a few more granualar errors and use where appropriate.