### PR TITLE
Add `checks: write` permission to cargo-audit job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
           interval: "monthly"
           time: "00:00"
       cooldown:
-          default-days: 14
+          default-days: 60
       groups:
           all:
             patterns: ["*"]
@@ -19,7 +19,7 @@ updates:
           interval: "monthly"
           time: "00:00"
       cooldown:
-          default-days: 14
+          default-days: 60
       groups:
           all:
             patterns: ["*"]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            checks: write
             issues: write
         strategy:
             fail-fast: false

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -263,8 +263,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.8.0",
+ "crossbeam-utils 0.7.0",
  "maybe-uninit",
 ]
 
@@ -276,10 +276,19 @@ checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 dependencies = [
  "autocfg 0.1.6",
  "cfg-if 0.1.2",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.0",
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils 0.8.18",
 ]
 
 [[package]]
@@ -288,7 +297,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.0",
 ]
 
 [[package]]
@@ -300,6 +309,15 @@ dependencies = [
  "autocfg 0.1.6",
  "cfg-if 0.1.2",
  "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -635,7 +653,7 @@ checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.0",
  "lazy_static",
  "num_cpus",
 ]
@@ -702,6 +720,7 @@ dependencies = [
  "clap_builder",
  "clap_lex",
  "criterion",
+ "crossbeam-epoch 0.9.20",
  "foldhash",
  "hashbrown",
  "hex-conservative 1.0.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -473,9 +473,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -559,6 +559,7 @@ dependencies = [
  "clap_builder",
  "clap_lex",
  "criterion",
+ "crossbeam-epoch",
  "foldhash",
  "hashbrown",
  "hex-conservative 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bitcoin-io = { version = "0.5.0", default-features = false, features = ["alloc"]
 foldhash = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-rand = { version = "0.9.2" }
+rand = { version = "0.9.3" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.81" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ rand = { version = "0.9.3" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.81" }
-
-# These pins are necessary for `Cargo-minimal.lock`:
-clap = { version = "4.5.61" } # blame: criterion
-clap_builder = { version = "4.5.61" } # blame: criterion
-clap_lex = { version = "=1.0.1" } # blame: criterion
-regex = { version = "1.10.0" } # blame: criterion
+# Transitive dependency pins:
+clap = { version = "4.5.61" } # blame: criterion v0.5.1
+clap_builder = { version = "4.5.61" } # blame: criterion v0.5.1
+clap_lex = { version = "=1.0.1" } # blame: criterion v0.5.1
+crossbeam-epoch = { version = "0.9.20" } # blame: criterion v0.5.1 (RUSTSEC-2026-0204)
+regex = { version = "1.10.0" } # blame: criterion v0.5.1
 
 [[bench]]
 name = "accumulator"


### PR DESCRIPTION
Adds the missing `checks: write` permission to the `cargo-audit` job such that `rustsec/audit-check` can open issues when it encounters a vulnerable dependency.

ref: https://github.com/mit-dci/rustreexo/actions/runs/28887247069/job/85690487562

Also increases `dependabot`'s cooldown to 60 days, bumps `rand` to v0.9.3 to patch [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) and pins `crossbeam-epoch` to v0.9.20 to patch [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204).